### PR TITLE
rhel7 make option

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,13 +21,15 @@ RUN yum -y install --setopt=tsflags=nodocs java net-tools git \
     && yum autoremove git -y \
     && yum clean all
 
-#set ownership of nuodb home
-#RUN chown -R nobody:nobody /opt/nuodb
-
 ADD scripts /scripts
 COPY help.1 /
 COPY LICENSE /licenses/
 
-#USER 99
+RUN useradd -l -u 1000 -r -g 0 -d /opt/nuodb -s /sbin/nologin -c "nuodb user" nuodb \
+#set ownership of nuodb home
+    && chown -R nuodb:0 /opt/{nuodb,nuoca} /scripts \
+    && chmod -R g=u /opt/{nuodb,nuoca} /scripts
+
+USER 1000
 
 ENTRYPOINT ["/scripts/entrypoint.sh"]

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -22,13 +22,15 @@ RUN yum -y install --disablerepo "*" --enablerepo rhel-7-server-rpms,rhel-7-serv
     && yum autoremove git -y \
     && yum clean all
 
-#set ownership of nuodb home
-#RUN chown -R nobody:nobody /opt/nuodb
-
 ADD scripts /scripts
 COPY help.1 /
 COPY LICENSE /licenses/
 
-#USER 99
+RUN useradd -l -u 1000 -r -g 0 -d /opt/nuodb -s /sbin/nologin -c "nuodb user" nuodb \
+#set ownership of nuodb home
+    && chown -R nuodb:0 /opt/{nuodb,nuoca} /scripts \
+    && chmod -R g=u /opt/{nuodb,nuoca} /scripts
+
+USER 1000
 
 ENTRYPOINT ["/scripts/entrypoint.sh"]

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -1,4 +1,4 @@
-FROM docker.io/centos:7
+FROM registry.access.redhat.com/rhel7
 
 ARG RELEASE_PACKAGE=35
 ARG BUILD=8
@@ -10,7 +10,8 @@ LABEL "name"="$VERSION" \
       "version"="$RELEASE_BUILD" \
       "release"="$BUILD"
 
-RUN yum -y install --setopt=tsflags=nodocs java net-tools git \
+RUN yum -y install --disablerepo "*" --enablerepo rhel-7-server-rpms,rhel-7-server-ose-3.5-rpms \
+      --setopt=tsflags=nodocs java net-tools git atomic-openshift-clients \
     && curl -SL http://bamboo.bo2.nuodb.com/bamboo/artifact/RELEASE-PACKAGE$RELEASE_PACKAGE/shared/build-$BUILD/Linux-.tar.gz/$VERSION-$RELEASE_BUILD.$BUILD.linux.x86_64.tar.gz -o /tmp/nuodb.tgz \
     && mkdir -p /opt/nuodb \
     && tar -xvf /tmp/nuodb.tgz -C /opt/nuodb --strip-components 1 \

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ test:
 	$(eval CONTAINERID=$(shell docker run -tdi ${CONTEXT}/${IMAGE_NAME}:${TARGET}-${VERSION}))
 	@sleep 5
 	@docker exec ${CONTAINERID} ps aux
+	@docker logs ${CONTAINERID}
 	@docker rm -f ${CONTAINERID}
 
 #run:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,33 @@
+CONTEXT = nuodbopenshift
+VERSION = 2.6.1
+IMAGE_NAME = nuodb-ce
+REGISTRY = docker-registry.default.svc.cluster.local
+
+# Allow user to pass in OS build options
+ifeq ($(TARGET),rhel7)
+	DFILE := Dockerfile.${TARGET}
+else
+	TARGET := centos7
+	DFILE := Dockerfile
+endif
+
+all: build
+build:
+	docker build --pull -t ${CONTEXT}/${IMAGE_NAME}:${TARGET}-${VERSION} -t ${CONTEXT}/${IMAGE_NAME} -f ${DFILE} .
+	@if docker images ${CONTEXT}/${IMAGE_NAME}:${TARGET}-${VERSION}; then touch build; fi
+
+lint:
+	dockerfile_lint -f Dockerfile
+	dockerfile_lint -f Dockerfile.rhel7
+
+test:
+	$(eval CONTAINERID=$(shell docker run -tdi ${CONTEXT}/${IMAGE_NAME}:${TARGET}-${VERSION}))
+	@sleep 5
+	@docker exec ${CONTAINERID} ps aux
+	@docker rm -f ${CONTAINERID}
+
+#run:
+#	docker run -tdi -u `shuf -i 1000010000-1000020000 -n 1` ${CONTEXT}/${IMAGE_NAME}:${TARGET}-${VERSION}
+
+clean:
+	rm -f build

--- a/README.md
+++ b/README.md
@@ -12,8 +12,19 @@
  `VERSION=nuodb or nuodb-ce` - Community Edition or Full version of NuoDB
 
 example:
+```shell
+# build on centos7
+$ make
+
+# OR
+
+# build on rhel7
+$ make TARGET=rhel7
+```
+
+further customizing the build w/ docker:
 ```bash
-Docker build \
+docker build \
     -t nuodb-2.6.1:latest \
     --build-arg RELEASE_PACKAGE=35 \
     --build-arg BUILD=8 \


### PR DESCRIPTION
 - added Makefile for creating centos7 and rhel7 images from same repo
 - combined important RUN commands to ensure image layers are as small as possible
 - switched to non-root nuodb user for runtime
 - removed sub-mgr from rhel build in favor of using build host entitlements
 - added yum clean all